### PR TITLE
Centralize Octokit version

### DIFF
--- a/Directory.Octokit.props
+++ b/Directory.Octokit.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <OctokitVersion>0.48.0</OctokitVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Octokit" Version="$(OctokitVersion)" />
+  </ItemGroup>
+</Project>

--- a/Directory.Version.props
+++ b/Directory.Version.props
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+  <Import Project="$(MSBuildThisFileDirectory)Directory.Octokit.props" />
   <PropertyGroup Condition="'$(VersionPrefix)'==''">
-    <VersionPrefix>0.48.0</VersionPrefix>
+    <VersionPrefix>$(OctokitVersion)</VersionPrefix>
     <VersionSuffix>preview1</VersionSuffix>
   </PropertyGroup>
   <Import Condition="

--- a/TH-NETII Octokit Extensions.sln
+++ b/TH-NETII Octokit Extensions.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		AllRules.ruleset = AllRules.ruleset
 		Directory.Build.props = Directory.Build.props
 		Directory.Meta.props = Directory.Meta.props
+		Directory.Octokit.props = Directory.Octokit.props
 		Directory.Version.props = Directory.Version.props
 		LICENSE = LICENSE
 	EndProjectSection

--- a/src/THNETII.Octokit.DependencyInjection/THNETII.Octokit.DependencyInjection.csproj
+++ b/src/THNETII.Octokit.DependencyInjection/THNETII.Octokit.DependencyInjection.csproj
@@ -14,8 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="0.48.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.4" />
   </ItemGroup>
 
 </Project>

--- a/test/THNETII.Octokit.Test/THNETII.Octokit.Test.csproj
+++ b/test/THNETII.Octokit.Test/THNETII.Octokit.Test.csproj
@@ -14,7 +14,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />


### PR DESCRIPTION
Move package reference for Octokit to repository root props file.

Use Octokit version number for VersionPrefix